### PR TITLE
Fix duplicated salt in UnixDESEncoder

### DIFF
--- a/identity4j-utils/src/main/java/com/identity4j/util/crypt/impl/UnixDESEncoder.java
+++ b/identity4j-utils/src/main/java/com/identity4j/util/crypt/impl/UnixDESEncoder.java
@@ -72,7 +72,7 @@ public class UnixDESEncoder extends AbstractEncoder {
 				}
 			}
 			String saltString = new String(salt, charset);
-			return (saltString + DESCrypt.crypt(saltString, new String(toEncode, charset))).getBytes(charset);
+			return DESCrypt.crypt(saltString, new String(toEncode, charset)).getBytes(charset);
 		} catch (Exception e) {
 			throw new EncoderException(e);
 		}


### PR DESCRIPTION
Salt is already set by DESCrypt.crypt().

See https://github.com/nervepoint/identity4j/blob/develop/identity4j-utils/src/main/java/com/identity4j/util/unix/DESCrypt.java#L409